### PR TITLE
Increase num of changed files returned

### DIFF
--- a/terragrunt/find-changes/action.yml
+++ b/terragrunt/find-changes/action.yml
@@ -19,7 +19,7 @@ runs:
   steps: 
     - id: changes
       run: |
-        URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ inputs.pull-request-number }}/files"
+        URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ inputs.pull-request-number }}/files?per_page=100"
         AUTH_HEADER="Authorization: Bearer ${{ inputs.github-token }}"
 
         changes=$(for d in $(curl -sH "${AUTH_HEADER}" ${URL} | jq -r '.[] | select(.status != "removed") | .filename' | grep terragrunt.hcl$ | sed 's/terragrunt.hcl//'); do


### PR DESCRIPTION
https://docs.github.com/en/free-pro-team@latest/rest/reference/pulls#list-pull-requests-files:
> The paginated response returns 30 files per page by default.

Adding request parameter `per_page` with value 100.