### PR TITLE
Upgrade to using Environment Files

### DIFF
--- a/aws/assume-role/action.yml
+++ b/aws/assume-role/action.yml
@@ -55,9 +55,9 @@ runs:
         echo "::add-mask::${AWS_SECRET_ACCESS_KEY}"
         echo "::add-mask::${AWS_SESSION_TOKEN}"
 
-        echo "::set-env name=AWS_ACCESS_KEY_ID::${AWS_ACCESS_KEY_ID}"
-        echo "::set-env name=AWS_SECRET_ACCESS_KEY::${AWS_SECRET_ACCESS_KEY}"
-        echo "::set-env name=AWS_SESSION_TOKEN::${AWS_SESSION_TOKEN}"
+        echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${GITHUB_ENV}
+        echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${GITHUB_ENV}
+        echo "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}" >> ${GITHUB_ENV}
       shell: bash
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.access-key-id }}


### PR DESCRIPTION
Removes warning when deprecated `set-env` was used:

> Warning: The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/