### PR TITLE
Add simple slack notify action

### DIFF
--- a/slack-notify/action.yml
+++ b/slack-notify/action.yml
@@ -10,5 +10,5 @@ runs:
   using: composite
   steps:
     - run: |
-        echo curl -X POST -H 'Content-Type: application/json' --data '${{ toJSON({text: inputs.message}) }}' $SLACK_WEBHOOK_URL
+        echo curl -X POST -H 'Content-Type: application/json' --data '{"text":${{ toJSON(inputs.message) }}}' $SLACK_WEBHOOK_URL
       shell: bash

--- a/slack-notify/action.yml
+++ b/slack-notify/action.yml
@@ -2,13 +2,13 @@ name: slack-notify
 description: Sends a slack notification
 
 inputs:
-  message:
-    description: Slack message
+  text:
+    description: Message text
     required: true
 
 runs:
   using: composite
   steps:
     - run: |
-        echo curl -X POST -H 'Content-Type: application/json' --data '{"text":${{ toJSON(inputs.message) }}}' $SLACK_WEBHOOK_URL
+        echo curl -X POST -H 'Content-Type: application/json' --data '{"text":${{ toJSON(inputs.text) }}}' "$SLACK_WEBHOOK_URL"
       shell: bash

--- a/slack-notify/action.yml
+++ b/slack-notify/action.yml
@@ -10,5 +10,5 @@ runs:
   using: composite
   steps:
     - run: |
-        echo curl -X POST -H 'Content-Type: application/json' --data '{"text":${{ toJSON(inputs.text) }}}' "$SLACK_WEBHOOK_URL"
+        curl -X POST -H 'Content-Type: application/json' --data '{"text":${{ toJSON(inputs.text) }}}' "$SLACK_WEBHOOK_URL"
       shell: bash

--- a/slack-notify/action.yml
+++ b/slack-notify/action.yml
@@ -3,7 +3,7 @@ description: Sends a slack notification
 
 inputs:
   text:
-    description: Message text
+    description: Message text (free-form string)
     required: true
 
 runs:

--- a/slack-notify/action.yml
+++ b/slack-notify/action.yml
@@ -1,0 +1,13 @@
+name: slack-notify
+description: Sends a slack notification
+
+inputs:
+  message:
+    description: Slack message
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - run: curl -X POST -H 'Content-type: application/json' --data '${{ toJSON({text: inputs.message}) }}' SLACK_WEBHOOK_URL
+      shell: bash

--- a/slack-notify/action.yml
+++ b/slack-notify/action.yml
@@ -9,5 +9,5 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: echo curl -X POST -H 'Content-type: application/json' --data '{"text":"${{ toJSON(inputs.message) }}"}' $SLACK_WEBHOOK_URL
+    - run: echo curl -X POST -H 'Content-type: application/json' --data '{"text":"${{ inputs.message }}"}' $SLACK_WEBHOOK_URL
       shell: bash

--- a/slack-notify/action.yml
+++ b/slack-notify/action.yml
@@ -9,5 +9,4 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: echo curl -X POST -H 'Content-type: application/json' --data '${{ toJSON({text: inputs.message}) }}' $SLACK_WEBHOOK_URL
-      shell: bash
+    - run: echo curl -X POST -H 'Content-type: application/json' --data '${{ toJSON({"text": inputs.message}) }}' $SLACK_WEBHOOK_URL

--- a/slack-notify/action.yml
+++ b/slack-notify/action.yml
@@ -9,4 +9,5 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: echo curl -X POST -H 'Content-type: application/json' --data '${{ toJSON({"text": inputs.message}) }}' $SLACK_WEBHOOK_URL
+    - run: echo curl -X POST -H 'Content-type: application/json' --data '{"text":"${{ toJSON(inputs.message) }}"}' $SLACK_WEBHOOK_URL
+      shell: bash

--- a/slack-notify/action.yml
+++ b/slack-notify/action.yml
@@ -9,5 +9,5 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: curl -X POST -H 'Content-type: application/json' --data '${{ toJSON({text: inputs.message}) }}' SLACK_WEBHOOK_URL
+    - run: echo curl -X POST -H 'Content-type: application/json' --data '${{ toJSON({text: inputs.message}) }}' $SLACK_WEBHOOK_URL
       shell: bash

--- a/slack-notify/action.yml
+++ b/slack-notify/action.yml
@@ -10,5 +10,5 @@ runs:
   using: composite
   steps:
     - run: |
-        echo curl -X POST -H 'Content-Type: application/json' --data '${{ toJSON({"text": inputs.message}) }}' $SLACK_WEBHOOK_URL
+        echo curl -X POST -H 'Content-Type: application/json' --data '${{ toJSON({text: inputs.message}) }}' $SLACK_WEBHOOK_URL
       shell: bash

--- a/slack-notify/action.yml
+++ b/slack-notify/action.yml
@@ -9,5 +9,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: echo curl -X POST -H 'Content-type: application/json' --data '${{ inputs.message }}' $SLACK_WEBHOOK_URL
+    - run: |
+        echo curl -X POST -H 'Content-Type: application/json' --data '${{ toJSON({"text": inputs.message}) }}' $SLACK_WEBHOOK_URL
       shell: bash

--- a/slack-notify/action.yml
+++ b/slack-notify/action.yml
@@ -9,5 +9,5 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: echo curl -X POST -H 'Content-type: application/json' --data '{"text":"${{ inputs.message }}"}' $SLACK_WEBHOOK_URL
+    - run: echo curl -X POST -H 'Content-type: application/json' --data '${{ inputs.message }}' $SLACK_WEBHOOK_URL
       shell: bash


### PR DESCRIPTION
Generic action to send a slack notification via slack app webhooks. Sample usage:

```
steps:
  - name: Slack notify
    uses: pafcloud/terraform-actions/slack-notify@jpalomaki-patch-1
    with:
      text: |
        string will be json encoded so can contain
        "'s
           and newlines
    env:
      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
```