### PR TITLE
Read terraform and terragrunt versions from file

### DIFF
--- a/terraform/version/action.yml
+++ b/terraform/version/action.yml
@@ -2,6 +2,10 @@ name: Select terraform version to use
 description: Like tfenv - check path for .terraform-version file and use version specified there. Otherwise return default version.
 
 inputs:
+  default-version:
+    description: Default version to use. .terraform-version can override this.
+    default: 0.12.29
+    required: true
   working-directory:
     description: Path within repository
     required: true
@@ -19,7 +23,7 @@ runs:
   steps: 
     - id: main
       run: |
-        version="0.12.29"
+        version="${{ inputs.default-version }}"
         if [ -f .terraform-version ]; then
           version=$(cat .terraform-version)
         fi

--- a/terraform/version/action.yml
+++ b/terraform/version/action.yml
@@ -1,0 +1,29 @@
+name: Select terraform version to use
+description: Like tfenv - check path for .terraform-version file and use vesion specified there. Otherwise return default version.
+
+inputs:
+  working-directory:
+    description: Path within repository
+    required: true
+
+outputs:
+  version:
+    description: Terraform version to use
+    value: ${{ steps.main.outputs.version }}
+  checksum:
+    description: Terraform binary sha256 checksum
+    value: ${{ steps.main.outputs.checksum }}
+
+runs:
+  using: composite
+  steps: 
+    - id: main
+      run: |
+        version="0.12.29"
+        if [ -f .terraform-version ]; then
+          version=$(cat .terraform-version)
+        fi
+
+        echo ::set-output name=version::${version}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}

--- a/terraform/version/action.yml
+++ b/terraform/version/action.yml
@@ -1,5 +1,5 @@
 name: Select terraform version to use
-description: Like tfenv - check path for .terraform-version file and use vesion specified there. Otherwise return default version.
+description: Like tfenv - check path for .terraform-version file and use version specified there. Otherwise return default version.
 
 inputs:
   working-directory:

--- a/terragrunt/version/action.yml
+++ b/terragrunt/version/action.yml
@@ -1,0 +1,35 @@
+name: Select terragrunt version to use
+description: Like tgenv - check path for .terragrimt-version file and use vesion specified there. Otherwise return default version.
+
+inputs:
+  working-directory:
+    description: Path within repository
+    required: true
+
+outputs:
+  version:
+    description: Terragrunt version to use
+    value: ${{ steps.main.outputs.version }}
+  checksum:
+    description: Terragrunt binary sha256 checksum
+    value: ${{ steps.main.outputs.checksum }}
+
+runs:
+  using: composite
+  steps: 
+    - id: main
+      run: |
+        declare -A checksums=(
+          ["0.27.1"]="b9f174e6613fe84121352ecdd238783504b642d390df87f8f8d760b42c44c02a"
+          ["0.24.4"]="f65a22becc185af5291870b04653939cab0cee86beda97fd774feb6dc822b416"
+        )
+
+        version="0.24.4"
+        if [ -f .terragrunt-version ]; then
+          version=$(cat .terragrunt-version)
+        fi
+
+        echo ::set-output name=version::${version}
+        echo ::set-output name=checksum::${checksums[$version]}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}

--- a/terragrunt/version/action.yml
+++ b/terragrunt/version/action.yml
@@ -1,5 +1,5 @@
 name: Select terragrunt version to use
-description: Like tgenv - check path for .terragrimt-version file and use vesion specified there. Otherwise return default version.
+description: Like tgenv - check path for .terragrunt-version file and use version specified there. Otherwise return default version.
 
 inputs:
   working-directory:

--- a/terragrunt/version/action.yml
+++ b/terragrunt/version/action.yml
@@ -29,7 +29,14 @@ runs:
           version=$(cat .terragrunt-version)
         fi
 
+        checksum=${checksums[$version]}
+        if [ "${checksum}" == "" ]; then
+          echo "Checksum is missing for version ${version}. Check version or update this composite run step action to include new checksum."
+          echo "Exiting."
+          exit 1
+        fi
+
         echo ::set-output name=version::${version}
-        echo ::set-output name=checksum::${checksums[$version]}
+        echo ::set-output name=checksum::${checksum}
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/terragrunt/version/action.yml
+++ b/terragrunt/version/action.yml
@@ -2,6 +2,10 @@ name: Select terragrunt version to use
 description: Like tgenv - check path for .terragrunt-version file and use version specified there. Otherwise return default version.
 
 inputs:
+  default-version:
+    description: Default version to use. .terragrunt-version can override this.
+    default: 0.24.4
+    required: true
   working-directory:
     description: Path within repository
     required: true
@@ -24,7 +28,7 @@ runs:
           ["0.24.4"]="f65a22becc185af5291870b04653939cab0cee86beda97fd774feb6dc822b416"
         )
 
-        version="0.24.4"
+        version="${{ inputs.default-version }}"
         if [ -f .terragrunt-version ]; then
           version=$(cat .terragrunt-version)
         fi


### PR DESCRIPTION
If current working directory has `.terraform-version`,  `.terragrunt-version`  use these files to read terraform , terragrunt versions to use later in setup steps.

This is similar to what `tfenv` and `tgenv` are using.