### PR TITLE
Make output-comment easier to read

### DIFF
--- a/terraform/pr-comment/action.yml
+++ b/terraform/pr-comment/action.yml
@@ -37,7 +37,7 @@ runs:
 
           echo "<details${open}><summary>Show output</summary>"
           echo
-          echo "\`\`\`${fmt}"
+          echo "\`\`\`\.hcl${fmt}"
           echo "$3"
           echo "\`\`\`"
           echo "</details>"


### PR DESCRIPTION
Github markdown supports pretty output format for .hcl

See: https://github.com/pafcloud/module-data-storage/pull/111#issue-779114717

```
'''.hcl
plan output
'''
```