### PR TITLE
Add state serial checks

### DIFF
--- a/terraform/assert-state-unchanged/action.yml
+++ b/terraform/assert-state-unchanged/action.yml
@@ -1,5 +1,5 @@
 name: Asserts that state is unchanged
-description: Fetches saved terraform state serial and compares it to the most recent one.
+description: Fetches saved terraform state serial and compares it to the most recent one, failing fast if there is a difference
 
 inputs:
   pr-number:

--- a/terraform/assert-state-unchanged/action.yml
+++ b/terraform/assert-state-unchanged/action.yml
@@ -36,7 +36,7 @@ runs:
         echo "::debug::current state serial: $(< ${CURRENT_STATE_SERIAL})"
         echo "::debug::saved state serial: $(< ${SAVED_STATE_SERIAL})"
 
-        cmp ${CURRENT_STATE_SERIAL} ${SAVED_STATE_SERIAL} || error "The given terraform plan can no longer be applied because the state was changed by another operation after the plan was created. Try merging or rebasing fresh base branch to this branch - or open new pr."
+        cmp ${CURRENT_STATE_SERIAL} ${SAVED_STATE_SERIAL} || error "Current terraform plan can no longer be applied because the state was changed by another operation after the plan was created. Update the pull request branch from base branch to run terraform plan again"
 
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/terraform/assert-state-unchanged/action.yml
+++ b/terraform/assert-state-unchanged/action.yml
@@ -1,4 +1,4 @@
-name: Asserts that state is unchanged
+name: Asserts that terraform state is unchanged
 description: Fetches saved terraform state serial and compares it to the most recent one, failing fast if there is a difference
 
 inputs:

--- a/terraform/assert-state-unchanged/action.yml
+++ b/terraform/assert-state-unchanged/action.yml
@@ -1,0 +1,45 @@
+name: Asserts that state is unchanged
+description: Fetches saved terraform state serial and compares it to the most recent one.
+
+inputs:
+  pr-number:
+    description: Pull request number
+    required: true
+  working-directory:
+    description: Working directory
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - run: |
+        # Fetch state serials: current from state and saved from actions artifacts
+        CURRENT_STATE_SERIAL=${RUNNER_TEMP}/state-serial.cur
+        ARTIFACT_NAME=$(echo ${WORKING_DIRECTORY}_${PR_NUMBER} | tr '":<>|*?\\/' .)
+        SAVED_STATE_SERIAL="${RUNNER_TEMP}/state-serial"
+        terragrunt state pull --terragrunt-tfpath terraform-bin | jq -r .serial > ${CURRENT_STATE_SERIAL}
+
+        echo "::debug::artifact name: ${ARTIFACT_NAME}"
+
+        error() {
+          gh pr comment ${PR_NUMBER} --body "$@"
+          exit 1
+        }
+
+        RC=0
+        gh run download -n "${ARTIFACT_NAME}" -D ${RUNNER_TEMP} || RC=$?
+        if [[ ${RC} -ne 0 || ! -f "${SAVED_STATE_SERIAL}" ]]; then
+          # Artifact expired or not found.
+          error "The given terraform plan can no longer be applied because saved terraform state serial is removed from github run artifacts (by default after 90 days). Try re-running the plan or open new pr."
+        fi
+
+        echo "::debug::current state serial: $(< ${CURRENT_STATE_SERIAL})"
+        echo "::debug::saved state serial: $(< ${SAVED_STATE_SERIAL})"
+
+        cmp ${CURRENT_STATE_SERIAL} ${SAVED_STATE_SERIAL} || error "The given terraform plan can no longer be applied because the state was changed by another operation after the plan was created. Try merging or rebasing fresh base branch to this branch - or open new pr."
+
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        PR_NUMBER: ${{ inputs.pr-number }}

--- a/terraform/save-state-serial/action.yml
+++ b/terraform/save-state-serial/action.yml
@@ -1,0 +1,34 @@
+name: Save terraform state serial number to actions artifacts.
+
+inputs:
+  pr-number:
+    description: Pull request number
+    required: true
+  working-directory:
+    description: Working directory
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Save state serial
+      id: save-serial
+      run: |
+        ARTIFACT_NAME=$(echo ${WORKING_DIRECTORY}_${PR_NUMBER} | tr '":<>|*?\\/' .)
+        STATE_SERIAL_PATH="${RUNNER_TEMP}/state-serial"
+
+        # call real terraform binary to get proper output
+        terragrunt state pull --terragrunt-tfpath terraform-bin | jq -r .serial > ${STATE_SERIAL_PATH}
+
+        echo ::set-output name=artifact-name::${ARTIFACT_NAME}
+        echo ::set-output name=path::${STATE_SERIAL_PATH}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        PR_NUMBER: ${{ inputs.pr-number}}
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.save-serial.outputs.artifact-name }}
+        path: ${{ steps.save-serial.outputs.path }}


### PR DESCRIPTION
**save-state-serial**
Serial is saved to run artifacts during plan.

**assert-state-unchanged**
Compare current state serial to saved one during apply and fail when there is diff.

Sample value for artifact name: `foo-sandbox.eu-west-1.s3-buckets.test._266`, where first part is state path with illegal chars changed to `.` char. Second part is pr-number.
