### PR TITLE
Strip leading and trailing whitespace from output

### DIFF
--- a/terraform/pr-comment/action.yml
+++ b/terraform/pr-comment/action.yml
@@ -35,7 +35,7 @@ runs:
           echo "<details${open}><summary>Show output</summary>"
           echo
           echo "\`\`\`${fmt}"
-          echo "$3"
+          echo "$(python3 -c 'import sys; print(sys.stdin.read().strip())' <<< $3)"
           echo "\`\`\`"
           echo "</details>"
         }


### PR DESCRIPTION
Because terraform apply's seem to emit extra newlines at output start and end