### PR TITLE
Add simple retry

### DIFF
--- a/terraform/pr-comment/action.yml
+++ b/terraform/pr-comment/action.yml
@@ -119,7 +119,9 @@ runs:
             exit 5
         esac
 
-        gh pr comment ${PULL_REQUEST_NUMBER} --body "${MSG}"
+        for t in 0 1 2 4 8 16 32; do
+          sleep $t && gh pr comment ${PULL_REQUEST_NUMBER} --body "${MSG}" && break
+        done
 
       shell: bash
       env:


### PR DESCRIPTION
To mitigate `Message: was submitted too quickly, Locations: [...]` which happens due to rate limiting