### PR TITLE
Bump terraform setup action

### DIFF
--- a/setup-tools/action.yml
+++ b/setup-tools/action.yml
@@ -69,7 +69,7 @@ runs:
         DEFAULT_TG_VERSION: ${{ inputs.default-terragrunt-version }}
   
     - name: Setup terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v2
       with:
         terraform_version: ${{ steps.resolve-versions.outputs.tf-version }}
         terraform_wrapper: ${{ inputs.install-terraform-wrapper }}


### PR DESCRIPTION
Seeing `(node:1641) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead`, which this may fix