### PR TITLE
Get rid of extra line in terragrunt plan outputs since upgrading terraform and terragrunt

### DIFF
--- a/run-terragrunt/action.yml
+++ b/run-terragrunt/action.yml
@@ -41,7 +41,7 @@ runs:
         exit_code="$?"
         if [ "$exit_code" = "0" ]; then
           temp_file="$(mktemp /tmp/terragrunt-output.XXXXXXXX.tmp)"
-          grep -v "Refreshing state...\|Reading...\|Preparing import...\|Read complete after" $output_file > $temp_file
+          grep -v "Refreshing state...\|Reading...\|Preparing import...\|Read complete after\|Downloading Terraform configurations from file" $output_file > $temp_file
           mv $temp_file $output_file
         fi
         set -e


### PR DESCRIPTION
Fixes this issue: https://github.com/pafcloud/terraform-workflows/issues/96