### PR TITLE
Trivy ignore

### DIFF
--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -51,7 +51,7 @@ runs:
         pwd
         trivyignore_file="$(upcat .trivyignore)"
         echo "--------"
-        echo $trivyignore_file
+        echo "Found Trivy ignore file: $trivyignore_file"
         echo "--------"
         pwd
         if [ -f "${{ inputs.working-directory }}/.trivyignore" ]; then

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -48,11 +48,12 @@ runs:
                 cd ..
             done
         }
+        pwd
         trivyignore_file="$(upcat .trivyignore)"
-        echo "--------" >> $GITHUB_OUTPUT
-        echo $trivyignore_file >> $GITHUB_OUTPUT
-        echo "--------" >> $GITHUB_OUTPUT
-
+        echo "--------"
+        echo $trivyignore_file
+        echo "--------"
+        pwd
         if [ -f "${{ inputs.working-directory }}/.trivyignore" ]; then
           echo "TRIVY_IGNORES=${{ inputs.working-directory }}/.trivyignore" >> $GITHUB_ENV
         else

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -36,7 +36,7 @@ runs:
         
     - id: check-trivyignore
       run: |
-        echo "pwd=$PWD"
+        echo "current working directory from env=$PWD"
         search_stop_dir="${{ inputs.working-directory }}"
         trivyignore_file=""
         upcat() {

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -49,9 +49,9 @@ runs:
             done
         }
         trivyignore_file="$(upcat .trivyignore)"
-        echo "--------"
-        echo $trivyignore_file
-        echo "--------"
+        echo "--------" >> $GITHUB_OUTPUT
+        echo $trivyignore_file >> $GITHUB_OUTPUT
+        echo "--------" >> $GITHUB_OUTPUT
 
         if [ -f "${{ inputs.working-directory }}/.trivyignore" ]; then
           echo "TRIVY_IGNORES=${{ inputs.working-directory }}/.trivyignore" >> $GITHUB_ENV

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -40,18 +40,16 @@ runs:
         trivyignore_file=""
         upcat() {
             file="$1"
-            latest_file_found=""
             while [ "$PWD" != "$search_stop_dir" -a "$PWD" != "/" ]; do
                 if [ -r "$file" ]; then
-                    # echo "$PWD/$file"
-                    # break
-                    latest_file_found="$PWD/$file"
+                  echo "$PWD/$file"
+                  break
                 fi
                 cd ..
             done
-            echo "$latest_file_found"            
         }
         pwd
+        echo "working directory= ${{ inputs.working-directory }}"
         trivyignore_file="$(upcat .trivyignore)"
         echo "--------"
         echo "Found Trivy ignore file: $trivyignore_file"

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -40,13 +40,16 @@ runs:
         trivyignore_file=""
         upcat() {
             file="$1"
+            latest_file_found=""
             while [ "$PWD" != "$search_stop_dir" -a "$PWD" != "/" ]; do
                 if [ -r "$file" ]; then
-                    echo "$PWD/$file"
-                    break
+                    # echo "$PWD/$file"
+                    # break
+                    latest_file_found="$PWD/$file"
                 fi
                 cd ..
             done
+            echo "$latest_file_found"            
         }
         pwd
         trivyignore_file="$(upcat .trivyignore)"

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -42,7 +42,7 @@ runs:
             file="$1"
             while [ "$PWD" != "$search_stop_dir" -a "$PWD" != "/" ]; do
                 if [ -r "$file" ]; then
-                    cat "$file"
+                    echo "$PWD/$file"
                     break
                 fi
                 cd ..

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -40,6 +40,7 @@ runs:
         scan-type: config
         scan-ref: ${{ inputs.working-directory }}/plan.tfplan
         severity: ${{ inputs.trivy-severity }}
+        trivyignores: ${{ inputs.working-directory }}/.trivyignore
         output: trivy.out
       continue-on-error: true
 

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -36,6 +36,23 @@ runs:
         
     - id: check-trivyignore
       run: |
+        search_stop_dir="${{ inputs.working-directory }}"
+        trivyignore_file=""
+        upcat() {
+            file="$1"
+            while [ "$PWD" != "$search_stop_dir" -a "$PWD" != "/" ]; do
+                if [ -r "$file" ]; then
+                    cat "$file"
+                    break
+                fi
+                cd ..
+            done
+        }
+        trivyignore_file="$(upcat .trivyignore)"
+        echo "--------"
+        echo $trivyignore_file
+        echo "--------"
+
         if [ -f "${{ inputs.working-directory }}/.trivyignore" ]; then
           echo "TRIVY_IGNORES=${{ inputs.working-directory }}/.trivyignore" >> $GITHUB_ENV
         else

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -50,6 +50,7 @@ runs:
             done
         }
         pwd
+        echo "current working directory from env=$PWD"
         echo "working directory= ${{ inputs.working-directory }}"
         trivyignore_file="$(upcat .trivyignore)"
         echo "--------"

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -36,9 +36,6 @@ runs:
         
     - id: check-trivyignore
       run: |
-        echo "current working directory from env=$PWD"
-        search_stop_dir="${{ inputs.working-directory }}"
-        trivyignore_file=""
         upcat() {
             file="$1"
             while [ "$PWD" != "$search_stop_dir" -a "$PWD" != "/" ]; do
@@ -49,18 +46,24 @@ runs:
                 cd ..
             done
         }
-        pwd
         echo "current working directory from env=$PWD"
-        echo "working directory= ${{ inputs.working-directory }}"
+        pwd
+        echo "inputs-work-dir= ${{ inputs.working-directory }}"
+        
+        search_stop_dir="${{ inputs.working-directory }}"
+        trivyignore_file=""
         trivyignore_file="$(upcat .trivyignore)"
+
         echo "--------"
         echo "Found Trivy ignore file: $trivyignore_file"
         echo "--------"
-        pwd
+
         if [ -f "${{ inputs.working-directory }}/.trivyignore" ]; then
           echo "TRIVY_IGNORES=${{ inputs.working-directory }}/.trivyignore" >> $GITHUB_ENV
+          echo "TRIVY_IGNORES=${{ inputs.working-directory }}/.trivyignore"
         else
           echo "TRIVY_IGNORES=" >> $GITHUB_ENV
+          echo "did not found trivy ignore"
         fi
       shell: bash
       env:

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -46,7 +46,7 @@ runs:
         WORKING_DIR: ${{ inputs.working-directory }}
         
     - id: run
-      uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55 # 0.19.0
+      uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # 0.24.0
       with:
         scan-type: config
         scan-ref: ${{ inputs.working-directory }}/plan.tfplan

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -33,17 +33,26 @@ runs:
       env:
         TF_PLAN: ${{ inputs.terraform-plan }}
         WORKING_DIR: ${{ inputs.working-directory }}
-
+        
+    - id: check-trivyignore
+      run: |
+        if [ ! -f "${{ inputs.working-directory }}/.trivyignore" ]; then
+          echo "TRIVY_IGNORES=" >> $GITHUB_ENV
+        fi
+      shell: bash
+      env:
+        WORKING_DIR: ${{ inputs.working-directory }}
+        
     - id: run
       uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55 # 0.19.0
       with:
         scan-type: config
         scan-ref: ${{ inputs.working-directory }}/plan.tfplan
         severity: ${{ inputs.trivy-severity }}
-        trivyignores: ${{ inputs.working-directory }}/.trivyignore
+        trivyignores: ${{ env.TRIVY_IGNORES }}
         output: trivy.out
       continue-on-error: true
-
+        
     - id: post
       run: |
         echo "output<<EOF" >> $GITHUB_OUTPUT
@@ -56,3 +65,5 @@ runs:
       shell: bash
       env:
         WORKING_DIR: ${{ inputs.working-directory }}
+        
+

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -36,7 +36,9 @@ runs:
         
     - id: check-trivyignore
       run: |
-        if [ ! -f "${{ inputs.working-directory }}/.trivyignore" ]; then
+        if [ -f "${{ inputs.working-directory }}/.trivyignore" ]; then
+          echo "TRIVY_IGNORES=${{ inputs.working-directory }}/.trivyignore" >> $GITHUB_ENV
+        else
           echo "TRIVY_IGNORES=" >> $GITHUB_ENV
         fi
       shell: bash

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -36,6 +36,7 @@ runs:
         
     - id: check-trivyignore
       run: |
+        echo "pwd=$PWD"
         search_stop_dir="${{ inputs.working-directory }}"
         trivyignore_file=""
         upcat() {

--- a/terraform/run-trivy/action.yml
+++ b/terraform/run-trivy/action.yml
@@ -54,7 +54,7 @@ runs:
         trivyignores: ${{ env.TRIVY_IGNORES }}
         output: trivy.out
       continue-on-error: true
-        
+
     - id: post
       run: |
         echo "output<<EOF" >> $GITHUB_OUTPUT
@@ -67,5 +67,3 @@ runs:
       shell: bash
       env:
         WORKING_DIR: ${{ inputs.working-directory }}
-        
-


### PR DESCRIPTION
Add support for .trivyignore files in same folder as .terragrtunt.hcl file is located. 
Currently .trivyignore in root folder is honored.


Example syntax for .trivyignore:

```
# https://avd.aquasec.com/misconfig/avd-aws-0052
# Ignoring HIGH: Application load balancer is not set to drop invalid headers
AVD-AWS-0052
```

More details of when/how to use .trivyignore file:

https://pafcloud.atlassian.net/wiki/spaces/sysops/pages/4444454914/Terraform+Trivy+Scan

